### PR TITLE
Setting default limit fetching notifications

### DIFF
--- a/src/Notifications.php
+++ b/src/Notifications.php
@@ -52,7 +52,7 @@ class Notifications
      *
      * @return array
      */
-    public function getAll($limit = 50, $offset = null)
+    public function getAll($limit = 50, $offset = 0)
     {
         return $this->api->request('GET', '/notifications?' . http_build_query([
              'limit' => max(0, min(50, filter_var($limit, FILTER_VALIDATE_INT))),

--- a/src/Notifications.php
+++ b/src/Notifications.php
@@ -46,12 +46,13 @@ class Notifications
      *
      * Application authentication key and ID must be set.
      *
-     * @param int $limit  Results offset (results are sorted by ID)
-     * @param int $offset How many notifications to return (max 50)
+     * @param int $limit How many notifications to return (max 50) 
+     * @param int $offset Results offset (results are sorted by ID)
+     * 
      *
      * @return array
      */
-    public function getAll($limit = null, $offset = null)
+    public function getAll($limit = 50, $offset = null)
     {
         return $this->api->request('GET', '/notifications?' . http_build_query([
              'limit' => max(0, min(50, filter_var($limit, FILTER_VALIDATE_INT))),


### PR DESCRIPTION
If we call $notifications = $api->notifications->getAll(); without any parameter, notifications will not be showed.

Now, it will fetch lasts 50 notifications by default