### PR TITLE
Fixed csvExport method

### DIFF
--- a/src/Devices.php
+++ b/src/Devices.php
@@ -224,7 +224,7 @@ class Devices
      */
     public function csvExport()
     {
-        $url = '/players/csv-export?app_id=' . $this->api->getConfig()->getApplicationId();
+        $url = '/players/csv_export?app_id=' . $this->api->getConfig()->getApplicationId();
 
         return $this->api->request('POST', $url, [
             'headers' => [

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -218,7 +218,7 @@ class Devices
     /**
      * Export all information about devices in a CSV format for your application.
      *
-     * Application auth key must be set. 
+     * Application auth key must be set.
      *
      * @return array
      */

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -218,7 +218,7 @@ class Devices
     /**
      * Export all information about devices in a CSV format for your application.
      *
-     * Application auth key must be set.
+     * Application auth key must be set. 
      *
      * @return array
      */


### PR DESCRIPTION
Method ```csvExport``` got broken on [v0.1.10](https://github.com/norkunas/onesignal-php-api/blob/v0.1.10/src/Devices.php#L225). It was working fine on [v0.1.9](https://github.com/norkunas/onesignal-php-api/blob/v0.1.9/src/Devices.php#L225).