### PR TITLE
Update format string for send_after parameter

### DIFF
--- a/src/Notifications.php
+++ b/src/Notifications.php
@@ -289,8 +289,8 @@ class Notifications
             ->setDefined('send_after')
             ->setAllowedTypes('send_after', '\DateTimeInterface')
             ->setNormalizer('send_after', function (Options $options, \DateTime $value) {
-                //"2015-09-24 14:00:00 GMT-0700"
-                return $value->format('Y-m-d H:i:s TO');
+                //"2015-09-24 14:00:00-0700"
+                return $value->format('Y-m-d H:i:sO');
             })
             ->setDefined('delayed_option')
             ->setAllowedTypes('delayed_option', 'string')


### PR DESCRIPTION
The UTC time offset is sufficient to specify a time.

`t` indicates the timezone itself. For example, in `Melbourne/Australia` where I live, `t` is parsed as `AEST`. The old string would be `2015-09-24 14:00:00 AEST+1000`, which is incorrect because AEST by itself is `UTC+1000`. This caused OneSignal to double-handle the time zone (turning `+1000` into `+2000`)