### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ php:
     - 7.2
     - nightly
 
+matrix:
+    allow_failures:
+        - php: nightly
+
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": ">=5.6",
         "symfony/options-resolver": "~2.7|^3.0",
         "php-http/client-implementation": "^1.0",
         "php-http/client-common": "^1",
         "php-http/message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0",
+        "phpunit/phpunit": "^4.8.36",
         "php-http/guzzle6-adapter": "^1.1"
     },
     "autoload": {

--- a/tests/OneSignal/Tests/AbstractApiTest.php
+++ b/tests/OneSignal/Tests/AbstractApiTest.php
@@ -5,8 +5,9 @@ namespace OneSignal\Tests;
 use OneSignal\OneSignal;
 use OneSignal\Resolver\ResolverFactory;
 use OneSignal\Resolver\ResolverInterface;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractApiTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractApiTest extends TestCase
 {
     use ConfigMockerTrait;
 

--- a/tests/OneSignal/Tests/ConfigTest.php
+++ b/tests/OneSignal/Tests/ConfigTest.php
@@ -3,8 +3,9 @@
 namespace OneSignal\Tests;
 
 use OneSignal\Config;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     /**
      * @var Config

--- a/tests/OneSignal/Tests/OneSignalTest.php
+++ b/tests/OneSignal/Tests/OneSignalTest.php
@@ -5,8 +5,9 @@ namespace OneSignal\Tests;
 use OneSignal\Config;
 use OneSignal\OneSignal;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
-class OneSignalTest extends \PHPUnit_Framework_TestCase
+class OneSignalTest extends TestCase
 {
     /**
      * @var OneSignal

--- a/tests/OneSignal/Tests/Resolver/AppResolverTest.php
+++ b/tests/OneSignal/Tests/Resolver/AppResolverTest.php
@@ -3,8 +3,9 @@
 namespace OneSignal\Tests\Resolver;
 
 use OneSignal\Resolver\AppResolver;
+use PHPUnit\Framework\TestCase;
 
-class AppResolverTest extends \PHPUnit_Framework_TestCase
+class AppResolverTest extends TestCase
 {
     /**
      * @var AppResolver

--- a/tests/OneSignal/Tests/Resolver/DeviceFocusResolverTest.php
+++ b/tests/OneSignal/Tests/Resolver/DeviceFocusResolverTest.php
@@ -3,8 +3,9 @@
 namespace OneSignal\Tests\Resolver;
 
 use OneSignal\Resolver\DeviceFocusResolver;
+use PHPUnit\Framework\TestCase;
 
-class DeviceFocusResolverTest extends \PHPUnit_Framework_TestCase
+class DeviceFocusResolverTest extends TestCase
 {
     /**
      * @var DeviceFocusResolver

--- a/tests/OneSignal/Tests/Resolver/DevicePurchaseResolverTest.php
+++ b/tests/OneSignal/Tests/Resolver/DevicePurchaseResolverTest.php
@@ -3,8 +3,9 @@
 namespace OneSignal\Tests\Resolver;
 
 use OneSignal\Resolver\DevicePurchaseResolver;
+use PHPUnit\Framework\TestCase;
 
-class DevicePurchaseResolverTest extends \PHPUnit_Framework_TestCase
+class DevicePurchaseResolverTest extends TestCase
 {
     /**
      * @var DevicePurchaseResolver

--- a/tests/OneSignal/Tests/Resolver/DeviceResolverTest.php
+++ b/tests/OneSignal/Tests/Resolver/DeviceResolverTest.php
@@ -5,8 +5,9 @@ namespace OneSignal\Tests\Resolver;
 use OneSignal\Devices;
 use OneSignal\Resolver\DeviceResolver;
 use OneSignal\Tests\ConfigMockerTrait;
+use PHPUnit\Framework\TestCase;
 
-class DeviceResolverTest extends \PHPUnit_Framework_TestCase
+class DeviceResolverTest extends TestCase
 {
     use ConfigMockerTrait;
 

--- a/tests/OneSignal/Tests/Resolver/DeviceSessionResolverTest.php
+++ b/tests/OneSignal/Tests/Resolver/DeviceSessionResolverTest.php
@@ -3,8 +3,9 @@
 namespace OneSignal\Tests\Resolver;
 
 use OneSignal\Resolver\DeviceSessionResolver;
+use PHPUnit\Framework\TestCase;
 
-class DeviceSessionResolverTest extends \PHPUnit_Framework_TestCase
+class DeviceSessionResolverTest extends TestCase
 {
     /**
      * @var DeviceSessionResolver

--- a/tests/OneSignal/Tests/Resolver/NotificationResolverTest.php
+++ b/tests/OneSignal/Tests/Resolver/NotificationResolverTest.php
@@ -6,8 +6,9 @@ use OneSignal\Resolver\NotificationResolver;
 use OneSignal\Tests\ConfigMockerTrait;
 use OneSignal\Tests\PrivateAccessorTrait;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use PHPUnit\Framework\TestCase;
 
-class NotificationResolverTest extends \PHPUnit_Framework_TestCase
+class NotificationResolverTest extends TestCase
 {
     use ConfigMockerTrait;
     use PrivateAccessorTrait;

--- a/tests/OneSignal/Tests/Resolver/ResolverFactoryTest.php
+++ b/tests/OneSignal/Tests/Resolver/ResolverFactoryTest.php
@@ -10,8 +10,9 @@ use OneSignal\Resolver\DeviceSessionResolver;
 use OneSignal\Resolver\NotificationResolver;
 use OneSignal\Resolver\ResolverFactory;
 use OneSignal\Tests\ConfigMockerTrait;
+use PHPUnit\Framework\TestCase;
 
-class ResolverFactoryTest extends \PHPUnit_Framework_TestCase
+class ResolverFactoryTest extends TestCase
 {
     use ConfigMockerTrait;
 


### PR DESCRIPTION
# Changed log

- Set the PHPUnit version `^4.8.36` to be compatible with the latest PHPUnit versions.
- Using the class-based PHPUnit namespace to be compatible with the stable PHPUnit version.