### PR TITLE
Added undocumented Notification parameter web_push_topic

### DIFF
--- a/src/Resolver/NotificationResolver.php
+++ b/src/Resolver/NotificationResolver.php
@@ -211,6 +211,8 @@ class NotificationResolver implements ResolverInterface
             ->setAllowedTypes('email_from_address', 'string')
             ->setDefined('external_id')
             ->setAllowedTypes('external_id', 'string')
+            ->setDefined('web_push_topic')
+            ->setAllowedTypes('web_push_topic', 'string')
             ->resolve($data);
     }
 


### PR DESCRIPTION
This parameter allows the usage of Push Notifications "tag" property (https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API#Replacing_existing_notifications). It was shared by a OneSignal client at StackOverflow (https://stackoverflow.com/a/47769559/269622)