### PR TITLE
Added segment_name and last_active_since parameters to CSV export

### DIFF
--- a/src/Devices.php
+++ b/src/Devices.php
@@ -185,11 +185,11 @@ class Devices
      *
      * Application auth key must be set.
      *
-     * @param array $extraFields Additional fields that you wish to include.
-     *                           Currently supports: "location", "country", "rooted"
-     * @param string $segmentName A segment name to filter the scv export by.
-     *                           Only devices from that segment will make it into the export
-     * @param int $lastActiveSince An epoch to filter results to users active after this time
+     * @param array $extraFields    Additional fields that you wish to include.
+     *                              Currently supports: "location", "country", "rooted"
+     * @param string $segmentName   A segment name to filter the scv export by.
+     *                              Only devices from that segment will make it into the export
+     * @param int $lastActiveSince  An epoch to filter results to users active after this time
      *
      * @return array
      */

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -190,7 +190,7 @@ class Devices
      *
      * @return array
      */
-    public function csvExport(array $extraFields = [], $segmentName = null, int $lastActiveSince = null)
+    public function csvExport(array $extraFields = [], $segmentName = null, $lastActiveSince = null)
     {
         $url = '/players/csv_export?app_id='.$this->api->getConfig()->getApplicationId();
 

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -190,7 +190,7 @@ class Devices
      *
      * @return array
      */
-    public function csvExport(array $extraFields = [], string $segmentName = null, int $lastActiveSince = null)
+    public function csvExport(array $extraFields = [], $segmentName = null, int $lastActiveSince = null)
     {
         $url = '/players/csv_export?app_id='.$this->api->getConfig()->getApplicationId();
 

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -202,12 +202,12 @@ class Devices
             'extra_fields' => $extraFields,
         ];
 
-        if(!is_null($segmentName)) {
+        if (!is_null($segmentName)) {
             $body['segment_name'] = $segmentName;
         }
 
-        if(!is_null($lastActiveSince)) {
-            $body['last_active_since'] = (string)$lastActiveSince;
+        if (!is_null($lastActiveSince)) {
+            $body['last_active_since'] = (string) $lastActiveSince;
         }
 
         return $this->api->request('POST', $url, $headers, json_encode($body));

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -190,7 +190,7 @@ class Devices
      *
      * @return array
      */
-    public function csvExport(array $extraFields = [])
+    public function csvExport(array $extraFields = [], ?string $segmentName = null, ?int $lastActiveSince = null)
     {
         $url = '/players/csv_export?app_id='.$this->api->getConfig()->getApplicationId();
 
@@ -201,6 +201,14 @@ class Devices
         $body = [
             'extra_fields' => $extraFields,
         ];
+
+        if(!is_null($segmentName)) {
+            $body['segment_name'] = $segmentName;
+        }
+
+        if(!is_null($lastActiveSince)) {
+            $body['last_active_since'] = (string)$lastActiveSince;
+        }
 
         return $this->api->request('POST', $url, $headers, json_encode($body));
     }

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -185,11 +185,11 @@ class Devices
      *
      * Application auth key must be set.
      *
-     * @param array $extraFields    Additional fields that you wish to include.
-     *                              Currently supports: "location", "country", "rooted"
-     * @param string $segmentName   A segment name to filter the scv export by.
-     *                              Only devices from that segment will make it into the export
-     * @param int $lastActiveSince  An epoch to filter results to users active after this time
+     * @param array  $extraFields     Additional fields that you wish to include.
+     *                                Currently supports: "location", "country", "rooted"
+     * @param string $segmentName     A segment name to filter the scv export by.
+     *                                Only devices from that segment will make it into the export
+     * @param int    $lastActiveSince An epoch to filter results to users active after this time
      *
      * @return array
      */

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -190,7 +190,7 @@ class Devices
      *
      * @return array
      */
-    public function csvExport(array $extraFields = [], ?string $segmentName = null, ?int $lastActiveSince = null)
+    public function csvExport(array $extraFields = [], string $segmentName = null, int $lastActiveSince = null)
     {
         $url = '/players/csv_export?app_id='.$this->api->getConfig()->getApplicationId();
 

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -187,6 +187,9 @@ class Devices
      *
      * @param array $extraFields Additional fields that you wish to include.
      *                           Currently supports: "location", "country", "rooted"
+     * @param string $segmentName A segment name to filter the scv export by.
+     *                           Only devices from that segment will make it into the export
+     * @param int $lastActiveSince An epoch to filter results to users active after this time
      *
      * @return array
      */
@@ -202,11 +205,11 @@ class Devices
             'extra_fields' => $extraFields,
         ];
 
-        if (!is_null($segmentName)) {
+        if (null !== $segmentName) {
             $body['segment_name'] = $segmentName;
         }
 
-        if (!is_null($lastActiveSince)) {
+        if (null !== $lastActiveSince) {
             $body['last_active_since'] = (string) $lastActiveSince;
         }
 

--- a/tests/OneSignal/Tests/DevicesTest.php
+++ b/tests/OneSignal/Tests/DevicesTest.php
@@ -113,13 +113,15 @@ class DevicesTest extends AbstractApiTest
 
     public function testCsvExport()
     {
+        $lastActiveSince = time() - 30*86400;
+
         $expectedRequest = [
             'POST',
             '/players/csv_export?app_id=fakeApplicationId',
             ['Authorization' => 'Basic fakeApplicationAuthKey'],
-            '{"extra_fields":["myField1","myField2"]}',
+            '{"extra_fields":["myField1","myField2"],"segment_name":"Active Users","last_active_since":"'.$lastActiveSince.'"}',
         ];
 
-        $this->assertEquals($expectedRequest, $this->devices->csvExport(['myField1', 'myField2']));
+        $this->assertEquals($expectedRequest, $this->devices->csvExport(['myField1', 'myField2'], 'Active Users', $lastActiveSince));
     }
 }

--- a/tests/OneSignal/Tests/DevicesTest.php
+++ b/tests/OneSignal/Tests/DevicesTest.php
@@ -113,7 +113,7 @@ class DevicesTest extends AbstractApiTest
 
     public function testCsvExport()
     {
-        $lastActiveSince = time() - 30*86400;
+        $lastActiveSince = time() - 30 * 86400;
 
         $expectedRequest = [
             'POST',


### PR DESCRIPTION
CSV export did not support segment name and last active since parameters, but OneSignal API does as per documentation. This PR adds support for those parameters.