### PR TITLE
support for channel_for_external_user_ids option

### DIFF
--- a/src/Resolver/NotificationResolver.php
+++ b/src/Resolver/NotificationResolver.php
@@ -63,6 +63,8 @@ class NotificationResolver implements ResolverInterface
             ->setAllowedTypes('include_android_reg_ids', 'array')
             ->setDefined('include_external_user_ids')
             ->setAllowedTypes('include_external_user_ids', 'array')
+            ->setDefined('channel_for_external_user_ids')
+            ->setAllowedTypes('channel_for_external_user_ids', 'string')
             ->setDefined('include_wp_uris')
             ->setAllowedTypes('include_wp_uris', 'array')
             ->setDefined('include_wp_wns_uris')


### PR DESCRIPTION
Acording to [onesignal api](https://documentation.onesignal.com/reference):

_"If targeting push and email subscribers with same ids, use with `channel_for_external_user_ids` to indicate you are sending a push or email."_

`channel_for_external_user_ids` option is not currently supported.

![imagem](https://user-images.githubusercontent.com/5169137/64568823-9bbb4b00-d353-11e9-9859-bb7d98e92325.png)
