### PR TITLE
Implement 'Edit tags with external user id' API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ $newDevice = $oneSignal->devices()->add([
 ]);
 ```
 
+Update an existing device's tags in one of your OneSignal apps using the External User ID ([official documentation](https://documentation.onesignal.com/reference/edit-tags-with-external-user-id)):
+
+```php
+use OneSignal\Api\Devices;
+
+$externalUserId = '12345';
+$newDevice = $oneSignal->devices()->editTags($externalUserId, [
+    'tags' => [
+        'a' => '1',
+        'foo' => '',
+    ],
+]);
+```
+
 Update an existing device in your configured OneSignal application ([official documentation](https://documentation.onesignal.com/reference#edit-device)):
 
 ```php

--- a/src/Devices.php
+++ b/src/Devices.php
@@ -204,4 +204,21 @@ class Devices extends AbstractApi
 
         return $this->client->sendRequest($request);
     }
+
+    /**
+     * Update an existing device's tags using the External User ID.
+     *
+     * @param string $externalUserId External User ID
+     * @param array  $data           Tags data
+     */
+    public function editTags(string $externalUserId, array $data): array
+    {
+        $resolvedData = $this->resolverFactory->createDeviceTagsResolver()->resolve($data);
+
+        $request = $this->createRequest('PUT', "/apps/{$this->client->getConfig()->getApplicationId()}/users/$externalUserId");
+        $request = $request->withHeader('Content-Type', 'application/json');
+        $request = $request->withBody($this->createStream($resolvedData));
+
+        return $this->client->sendRequest($request);
+    }
 }

--- a/src/Resolver/DeviceTagsResolver.php
+++ b/src/Resolver/DeviceTagsResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OneSignal\Resolver;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DeviceTagsResolver implements ResolverInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(array $data): array
+    {
+        return (new OptionsResolver())
+            ->setDefined('tags')
+            ->setAllowedTypes('tags', 'array')
+            ->setRequired(['tags'])
+            ->resolve($data);
+    }
+}

--- a/src/Resolver/ResolverFactory.php
+++ b/src/Resolver/ResolverFactory.php
@@ -50,6 +50,11 @@ class ResolverFactory
         return new DeviceResolver($this->config, false);
     }
 
+    public function createDeviceTagsResolver(): DeviceTagsResolver
+    {
+        return new DeviceTagsResolver();
+    }
+
     public function createNotificationResolver(): NotificationResolver
     {
         return new NotificationResolver($this->config);

--- a/tests/DevicesTest.php
+++ b/tests/DevicesTest.php
@@ -297,4 +297,28 @@ class DevicesTest extends ApiTestCase
             'csv_file_url' => 'https://onesignal.com/csv_exports/b2f7f966-d8cc-11e4-bed1-df8f05be55ba/users_184948440ec0e334728e87228011ff41_2015-11-10.csv.gz',
         ], $responseData);
     }
+
+    public function testEditTags(): void
+    {
+        $client = $this->createClientMock(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('PUT', $method);
+            $this->assertSame(OneSignal::API_URL.'/apps/fakeApplicationId/users/12345', $url);
+            $this->assertArrayHasKey('accept', $options['normalized_headers']);
+            $this->assertArrayHasKey('content-type', $options['normalized_headers']);
+            $this->assertSame('Accept: application/json', $options['normalized_headers']['accept'][0]);
+            $this->assertSame('Content-Type: application/json', $options['normalized_headers']['content-type'][0]);
+
+            return new MockResponse($this->loadFixture('devices_edit_tags.json'), ['http_code' => 200]);
+        });
+
+        $devices = new Devices($client, new ResolverFactory($client->getConfig()));
+
+        $responseData = $devices->editTags('12345', [
+            'tags' => ['a' => '1', 'foo' => ''],
+        ]);
+
+        self::assertSame([
+            'success' => true,
+        ], $responseData);
+    }
 }

--- a/tests/Fixtures/devices_edit_tags.json
+++ b/tests/Fixtures/devices_edit_tags.json
@@ -1,0 +1,1 @@
+{"success": true}

--- a/tests/Resolver/DeviceTagsResolverTest.php
+++ b/tests/Resolver/DeviceTagsResolverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OneSignal\Tests\Resolver;
+
+use OneSignal\Resolver\DeviceTagsResolver;
+use OneSignal\Tests\OneSignalTestCase;
+use stdClass;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+
+class DeviceTagsResolverTest extends OneSignalTestCase
+{
+    /**
+     * @var DeviceTagsResolver
+     */
+    private $deviceResolver;
+
+    protected function setUp(): void
+    {
+        $this->deviceResolver = new DeviceTagsResolver();
+    }
+
+    public function testResolveWithValidValues(): void
+    {
+        $expectedData = [
+            'tags' => [
+                'a' => '1',
+                'foo' => '',
+            ],
+        ];
+
+        self::assertEquals($expectedData, $this->deviceResolver->resolve($expectedData));
+    }
+
+    public function testResolveWithMissingRequiredValue(): void
+    {
+        $this->expectException(MissingOptionsException::class);
+
+        $this->deviceResolver->resolve([]);
+    }
+
+    public function wrongValueTypesProvider(): iterable
+    {
+        yield [['tags' => 777]];
+        yield [['tags' => 'string']];
+        yield [['tags' => true]];
+        yield [['tags' => new stdClass()]];
+    }
+
+    /**
+     * @dataProvider wrongValueTypesProvider
+     */
+    public function testResolveWithWrongValueTypes(array $wrongOption): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $this->deviceResolver->resolve($wrongOption);
+    }
+
+    public function testResolveWithWrongOption(): void
+    {
+        $this->expectException(UndefinedOptionsException::class);
+
+        $this->deviceResolver->resolve(['device_tags' => 'wrongValue']);
+    }
+}


### PR DESCRIPTION
Hi! I have implemented `Edit tags with external user id` API endpoint!

Closes: https://github.com/norkunas/onesignal-php-api/issues/139