### PR TITLE
Implement View Outcomes endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ Delete Segments ([official documentation](https://documentation.onesignal.com/re
 $oneSignal->apps()->deleteSegment('application_id', 'segment_id');
 ```
 
+View the details of all the outcomes associated with your app ([official documentation](https://documentation.onesignal.com/reference/view-outcomes)):
+
+```php
+use OneSignal\Apps;
+use OneSignal\Devices;
+
+$outcomes = $oneSignal->apps()->outcomes('application_id', [
+    'outcome_names' => [
+        'os__session_duration.count',
+        'os__click.count',
+        'Sales, Purchase.sum',
+    ],
+    'outcome_time_range' => Apps::OUTCOME_TIME_RANGE_MONTH,
+    'outcome_platforms' => [Devices::IOS, Devices::ANDROID],
+    'outcome_attribution' => Apps::OUTCOME_ATTRIBUTION_DIRECT,
+]);
+```
+
 ### Devices API
 
 View the details of multiple devices in one of your OneSignal apps ([official documentation](https://documentation.onesignal.com/reference#view-devices)):
@@ -113,25 +131,11 @@ $device = $oneSignal->devices()->getOne('device_id');
 Register a new device to your configured OneSignal application ([official documentation](https://documentation.onesignal.com/reference#add-a-device)):
 
 ```php
-use OneSignal\Api\Devices;
+use OneSignal\Devices;
 
 $newDevice = $oneSignal->devices()->add([
     'device_type' => Devices::ANDROID,
     'identifier' => 'abcdefghijklmn',
-]);
-```
-
-Update an existing device's tags in one of your OneSignal apps using the External User ID ([official documentation](https://documentation.onesignal.com/reference/edit-tags-with-external-user-id)):
-
-```php
-use OneSignal\Api\Devices;
-
-$externalUserId = '12345';
-$newDevice = $oneSignal->devices()->editTags($externalUserId, [
-    'tags' => [
-        'a' => '1',
-        'foo' => '',
-    ],
 ]);
 ```
 
@@ -140,6 +144,18 @@ Update an existing device in your configured OneSignal application ([official do
 ```php
 $oneSignal->devices()->update('device_id', [
     'session_count' => 2,
+]);
+```
+
+Update an existing device's tags in one of your OneSignal apps using the External User ID ([official documentation](https://documentation.onesignal.com/reference/edit-tags-with-external-user-id)):
+
+```php
+$externalUserId = '12345';
+$response = $oneSignal->devices()->editTags($externalUserId, [
+    'tags' => [
+        'a' => '1',
+        'foo' => '',
+    ],
 ]);
 ```
 

--- a/src/Apps.php
+++ b/src/Apps.php
@@ -8,6 +8,15 @@ use OneSignal\Resolver\ResolverFactory;
 
 class Apps extends AbstractApi
 {
+    public const OUTCOME_ATTRIBUTION_TOTAL = 'total';
+    public const OUTCOME_ATTRIBUTION_UNATTRIBUTED = 'unattributed';
+    public const OUTCOME_ATTRIBUTION_INFLUENCED = 'influenced';
+    public const OUTCOME_ATTRIBUTION_DIRECT = 'direct';
+
+    public const OUTCOME_TIME_RANGE_MONTH = '1mo';
+    public const OUTCOME_TIME_RANGE_HOUR = '1h';
+    public const OUTCOME_TIME_RANGE_DAY = '1d';
+
     private $resolverFactory;
 
     public function __construct(OneSignal $client, ResolverFactory $resolverFactory)
@@ -113,6 +122,24 @@ class Apps extends AbstractApi
     public function deleteSegment(string $appId, string $segmentId): array
     {
         $request = $this->createRequest('DELETE', "/apps/$appId/segments/$segmentId");
+        $request = $request->withHeader('Authorization', "Basic {$this->client->getConfig()->getApplicationAuthKey()}");
+
+        return $this->client->sendRequest($request);
+    }
+
+    /**
+     * View the details of all the outcomes associated with your app.
+     *
+     * @param string $appId Application ID
+     * @param array  $data  Outcome data filters
+     */
+    public function outcomes(string $appId, array $data): array
+    {
+        $resolvedData = $this->resolverFactory->createOutcomesResolver()->resolve($data);
+
+        $queryString = preg_replace('/%5B\d+%5D/', '%5B%5D', http_build_query($resolvedData));
+
+        $request = $this->createRequest('GET', "/apps/$appId/outcomes?$queryString");
         $request = $request->withHeader('Authorization', "Basic {$this->client->getConfig()->getApplicationAuthKey()}");
 
         return $this->client->sendRequest($request);

--- a/src/Resolver/AppOutcomesResolver.php
+++ b/src/Resolver/AppOutcomesResolver.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OneSignal\Resolver;
+
+use OneSignal\Apps;
+use OneSignal\Devices;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AppOutcomesResolver implements ResolverInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(array $data): array
+    {
+        return (new OptionsResolver())
+            ->setDefined('outcome_names')
+            ->setAllowedTypes('outcome_names', 'string[]')
+            ->setDefined('outcome_time_range')
+            ->setAllowedTypes('outcome_time_range', 'string')
+            ->setAllowedValues('outcome_time_range', [Apps::OUTCOME_TIME_RANGE_HOUR, Apps::OUTCOME_TIME_RANGE_DAY, Apps::OUTCOME_TIME_RANGE_MONTH])
+            ->setDefault('outcome_time_range', Apps::OUTCOME_TIME_RANGE_HOUR)
+            ->setDefined('outcome_platforms')
+            ->setAllowedTypes('outcome_platforms', 'int[]')
+            ->setAllowedValues('outcome_platforms', static function (array $platforms): bool {
+                $intersect = array_intersect($platforms, [
+                    Devices::IOS,
+                    Devices::ANDROID,
+                    Devices::AMAZON,
+                    Devices::WINDOWS_PHONE,
+                    Devices::WINDOWS_PHONE_MPNS,
+                    Devices::CHROME_APP,
+                    Devices::CHROME_WEB,
+                    Devices::WINDOWS_PHONE_WNS,
+                    Devices::SAFARI,
+                    Devices::FIREFOX,
+                    Devices::MACOS,
+                    Devices::ALEXA,
+                    Devices::EMAIL,
+                    Devices::HUAWEI,
+                    Devices::SMS,
+                ]);
+
+                return count($intersect) === count($platforms);
+            })
+            ->setNormalizer('outcome_platforms', static function (Options $options, array $value): string {
+                return implode(',', $value);
+            })
+            ->setDefined('outcome_attribution')
+            ->setAllowedTypes('outcome_attribution', 'string')
+            ->setAllowedValues('outcome_attribution', [
+                Apps::OUTCOME_ATTRIBUTION_TOTAL,
+                Apps::OUTCOME_ATTRIBUTION_DIRECT,
+                Apps::OUTCOME_ATTRIBUTION_INFLUENCED,
+                Apps::OUTCOME_ATTRIBUTION_UNATTRIBUTED,
+            ])
+            ->setDefault('outcome_attribution', Apps::OUTCOME_ATTRIBUTION_TOTAL)
+            ->setRequired(['outcome_names'])
+            ->resolve($data);
+    }
+}

--- a/src/Resolver/ResolverFactory.php
+++ b/src/Resolver/ResolverFactory.php
@@ -25,6 +25,11 @@ class ResolverFactory
         return new SegmentResolver();
     }
 
+    public function createOutcomesResolver(): AppOutcomesResolver
+    {
+        return new AppOutcomesResolver();
+    }
+
     public function createDeviceSessionResolver(): DeviceSessionResolver
     {
         return new DeviceSessionResolver();

--- a/tests/Fixtures/apps_outcomes.json
+++ b/tests/Fixtures/apps_outcomes.json
@@ -1,0 +1,19 @@
+{
+  "outcomes": [
+    {
+      "id": "os__session_duration",
+      "value": 100,
+      "aggregation": "sum"
+    },
+    {
+      "id": "os__click",
+      "value": 4,
+      "aggregation": "count"
+    },
+    {
+      "id": "Sales, Purchase.count",
+      "value": 348,
+      "aggregation": "sum"
+    }
+  ]
+}

--- a/tests/Resolver/AppOutcomeResolverTest.php
+++ b/tests/Resolver/AppOutcomeResolverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OneSignal\Tests\Resolver;
+
+use OneSignal\Resolver\AppOutcomesResolver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+
+class AppOutcomeResolverTest extends TestCase
+{
+    /**
+     * @var AppOutcomesResolver
+     */
+    private $appResolver;
+
+    protected function setUp(): void
+    {
+        $this->appResolver = new AppOutcomesResolver();
+    }
+
+    public function testResolveWithValidValues(): void
+    {
+        $expectedData = [
+            'outcome_names' => [
+                'os__session_duration.count',
+                'os__click.count',
+            ],
+            'outcome_time_range' => '1mo',
+            'outcome_platforms' => [0, 1, 2],
+            'outcome_attribution' => 'direct',
+        ];
+
+        self::assertEquals(
+            array_merge($expectedData, [
+                'outcome_platforms' => '0,1,2',
+            ]),
+            $this->appResolver->resolve($expectedData)
+        );
+    }
+
+    public function testResolveWithMissingRequiredValue(): void
+    {
+        $this->expectException(MissingOptionsException::class);
+
+        $this->appResolver->resolve([]);
+    }
+
+    public function wrongValueTypesProvider(): iterable
+    {
+        yield [['outcome_names' => 100]];
+        yield [['outcome_names' => [1, 2]]];
+        yield [['outcome_time_range' => 1]];
+        yield [['outcome_time_range' => '2d']];
+        yield [['outcome_platforms' => 0]];
+        yield [['outcome_platforms' => ['0']]];
+        yield [['outcome_platforms' => [100]]];
+        yield [['outcome_attribution' => []]];
+        yield [['outcome_attribution' => 'indirect']];
+    }
+
+    /**
+     * @dataProvider wrongValueTypesProvider
+     */
+    public function testResolveWithWrongValueTypes(array $wrongOption): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        $requiredOptions = [
+            'outcome_names' => ['os__click.count'],
+        ];
+
+        $this->appResolver->resolve(array_merge($requiredOptions, $wrongOption));
+    }
+
+    public function testResolveWithWrongOption(): void
+    {
+        $this->expectException(UndefinedOptionsException::class);
+
+        $this->appResolver->resolve(['wrongOption' => 'wrongValue']);
+    }
+}


### PR DESCRIPTION
1. Implemented View Outcomes API method.
2. Introduced Enums for convenient group work with device types and outcome filters to typo mistakes. What do you think about this?
3. Did some manual encoding for `outcome_names` filter key to resolve issue with numeric keys in URL.
4. Improved readme from previous PR.

Closes: https://github.com/norkunas/onesignal-php-api/issues/140