### PR TITLE
add "name" to Notifications payload

### DIFF
--- a/src/Resolver/NotificationResolver.php
+++ b/src/Resolver/NotificationResolver.php
@@ -27,6 +27,8 @@ class NotificationResolver implements ResolverInterface
     public function resolve(array $data): array
     {
         return (new OptionsResolver())
+            ->setDefined('name')
+            ->setAllowedTypes('name', 'string')
             ->setDefined('contents')
             ->setAllowedTypes('contents', 'array')
             ->setDefined('headings')

--- a/tests/NotificationsTest.php
+++ b/tests/NotificationsTest.php
@@ -220,6 +220,7 @@ class NotificationsTest extends ApiTestCase
         $notifications = new Notifications($client, new ResolverFactory($client->getConfig()));
 
         $responseData = $notifications->add([
+            'name' => 'My Notification Name',
             'contents' => [
                 'en' => 'English Message',
             ],

--- a/tests/Resolver/NotificationResolverTest.php
+++ b/tests/Resolver/NotificationResolverTest.php
@@ -29,6 +29,7 @@ class NotificationResolverTest extends OneSignalTestCase
     public function testResolveWithValidValues(): void
     {
         $inputData = [
+            'name' => 'name',
             'contents' => ['value'],
             'headings' => ['value'],
             'subtitle' => ['value'],
@@ -133,6 +134,7 @@ class NotificationResolverTest extends OneSignalTestCase
 
     public function wrongValueTypesProvider(): iterable
     {
+        yield [['name' => 666]];
         yield [['contents' => 666]];
         yield [['headings' => 666]];
         yield [['subtitle' => 666]];

--- a/tests/Resolver/NotificationResolverTest.php
+++ b/tests/Resolver/NotificationResolverTest.php
@@ -29,7 +29,7 @@ class NotificationResolverTest extends OneSignalTestCase
     public function testResolveWithValidValues(): void
     {
         $inputData = [
-            'name' => 'name',
+            'name' => 'value',
             'contents' => ['value'],
             'headings' => ['value'],
             'subtitle' => ['value'],


### PR DESCRIPTION
Hi @norkunas I'm having issues with setting "name" on the Notification creation payload:

`Fatal error: Uncaught Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException: The option "name" does not exist. Defined options are: "adm_big_picture", "adm_group", "adm_group_message", "adm_large_icon", "adm_small_icon", "adm_sound", "amazon_background_data", "android_accent_color", "android_background_data", "android_background_layout", "android_channel_id", "android_group", "android_group_message", "android_led_color", "android_sound", "android_visibility", "apns_push_type_override", "app_id", "app_ids", "app_url", "big_picture", "buttons", "channel_for_external_user_ids", "chrome_big_picture", "chrome_icon", "chrome_web_badge", "chrome_web_icon", "chrome_web_image", "collapse_id", "content_available", "contents", "data", "delayed_option", "delivery_time_of_day", "email_body", "email_from_address", "email_from_name", "email_subject", "excluded_segments", "existing_android_channel_id", "external_id", "filters", "firefox_icon", "headings", "include_amazon_reg_ids", "include_android_reg_ids", "include_chrom [...]`

The "name" entry is noted on the documentation [here](https://documentation.onesignal.com/reference/create-notification#notification-content) and even seems [required for SMS](https://documentation.onesignal.com/reference/create-notification#sms-content).