### PR TITLE
Additional SMS related fields (on the Notifications payload)

### DIFF
--- a/src/Resolver/NotificationResolver.php
+++ b/src/Resolver/NotificationResolver.php
@@ -27,6 +27,8 @@ class NotificationResolver implements ResolverInterface
     public function resolve(array $data): array
     {
         return (new OptionsResolver())
+            ->setDefined('name')
+            ->setAllowedTypes('name', 'string')
             ->setDefined('contents')
             ->setAllowedTypes('contents', 'array')
             ->setDefined('headings')

--- a/src/Resolver/NotificationResolver.php
+++ b/src/Resolver/NotificationResolver.php
@@ -235,6 +235,10 @@ class NotificationResolver implements ResolverInterface
             ->setDefined('apns_push_type_override')
             ->setAllowedTypes('apns_push_type_override', 'string')
             ->setAllowedValues('apns_push_type_override', ['voip'])
+            ->setDefined('sms_from')
+            ->setAllowedTypes('sms_from', 'string')
+            ->setDefined('sms_media_urls')
+            ->setAllowedTypes('sms_media_urls', 'array')
             ->resolve($data);
     }
 

--- a/tests/NotificationsTest.php
+++ b/tests/NotificationsTest.php
@@ -220,6 +220,7 @@ class NotificationsTest extends ApiTestCase
         $notifications = new Notifications($client, new ResolverFactory($client->getConfig()));
 
         $responseData = $notifications->add([
+            'name' => 'My Notification Name',
             'contents' => [
                 'en' => 'English Message',
             ],

--- a/tests/Resolver/NotificationResolverTest.php
+++ b/tests/Resolver/NotificationResolverTest.php
@@ -29,6 +29,7 @@ class NotificationResolverTest extends OneSignalTestCase
     public function testResolveWithValidValues(): void
     {
         $inputData = [
+            'name' => 'name',
             'contents' => ['value'],
             'headings' => ['value'],
             'subtitle' => ['value'],
@@ -133,6 +134,7 @@ class NotificationResolverTest extends OneSignalTestCase
 
     public function wrongValueTypesProvider(): iterable
     {
+        yield [['name' => 666]];
         yield [['contents' => 666]];
         yield [['headings' => 666]];
         yield [['subtitle' => 666]];

--- a/tests/Resolver/NotificationResolverTest.php
+++ b/tests/Resolver/NotificationResolverTest.php
@@ -123,6 +123,8 @@ class NotificationResolverTest extends OneSignalTestCase
             'external_id' => 'value',
             'web_push_topic' => 'value',
             'apns_push_type_override' => 'voip',
+            'sms_from' => 'value',
+            'sms_media_urls' => ['value']
         ];
 
         $expectedData = $inputData;
@@ -218,6 +220,8 @@ class NotificationResolverTest extends OneSignalTestCase
         yield [['external_id' => 666]];
         yield [['web_push_topic' => 666]];
         yield [['apns_push_type_override' => 666]];
+        yield [['sms_from' => 666]];
+        yield [['sms_media_urls' => 666]];
     }
 
     /**

--- a/tests/Resolver/NotificationResolverTest.php
+++ b/tests/Resolver/NotificationResolverTest.php
@@ -124,7 +124,7 @@ class NotificationResolverTest extends OneSignalTestCase
             'web_push_topic' => 'value',
             'apns_push_type_override' => 'voip',
             'sms_from' => 'value',
-            'sms_media_urls' => ['value']
+            'sms_media_urls' => ['value'],
         ];
 
         $expectedData = $inputData;

--- a/tests/Resolver/NotificationResolverTest.php
+++ b/tests/Resolver/NotificationResolverTest.php
@@ -29,7 +29,7 @@ class NotificationResolverTest extends OneSignalTestCase
     public function testResolveWithValidValues(): void
     {
         $inputData = [
-            'name' => 'name',
+            'name' => 'value',
             'contents' => ['value'],
             'headings' => ['value'],
             'subtitle' => ['value'],


### PR DESCRIPTION
Hey @norkunas I figure we're still missing a couple of SMS related fields described [here](https://documentation.onesignal.com/reference/create-notification#sms-content), hope you can include this : )