### PR TITLE
add external user id auth hash in device to enable identity verification

### DIFF
--- a/src/Resolver/DeviceResolver.php
+++ b/src/Resolver/DeviceResolver.php
@@ -27,6 +27,8 @@ class DeviceResolver implements ResolverInterface
         $resolver = (new OptionsResolver())
             ->setDefined('identifier')
             ->setAllowedTypes('identifier', 'string')
+            ->setDefined('identifier_auth_hash')
+            ->setAllowedTypes('identifier_auth_hash', 'string')
             ->setDefined('language')
             ->setAllowedTypes('language', 'string')
             ->setDefined('timezone')

--- a/src/Resolver/DeviceResolver.php
+++ b/src/Resolver/DeviceResolver.php
@@ -69,6 +69,8 @@ class DeviceResolver implements ResolverInterface
             ->setAllowedTypes('country', 'string')
             ->setDefined('external_user_id')
             ->setAllowedTypes('external_user_id', 'string')
+            ->setDefined('external_user_id_auth_hash')
+            ->setAllowedTypes('external_user_id_auth_hash', 'string')
             ->setDefault('app_id', $this->config->getApplicationId())
             ->setAllowedTypes('app_id', 'string');
 

--- a/tests/Resolver/DeviceResolverTest.php
+++ b/tests/Resolver/DeviceResolverTest.php
@@ -47,6 +47,7 @@ class DeviceResolverTest extends OneSignalTestCase
             'lat' => 22.7624291,
             'country' => 'LT',
             'external_user_id' => 'value',
+            'external_user_id_auth_hash' => 'value',
             'app_id' => 'value',
             'ip' => '127.0.0.1',
         ];
@@ -115,6 +116,7 @@ class DeviceResolverTest extends OneSignalTestCase
         yield [['app_id' => 666]];
         yield [['device_type' => 666]];
         yield [['external_user_id' => 666]];
+        yield [['external_user_id_auth_hash' => 666]];
     }
 
     /**

--- a/tests/Resolver/DeviceResolverTest.php
+++ b/tests/Resolver/DeviceResolverTest.php
@@ -27,6 +27,7 @@ class DeviceResolverTest extends OneSignalTestCase
     {
         $expectedData = [
             'identifier' => 'value',
+            'identifier_auth_hash' => 'value',
             'language' => 'value',
             'timezone' => 3564,
             'game_version' => 'value',
@@ -94,6 +95,7 @@ class DeviceResolverTest extends OneSignalTestCase
     public function newDeviceWrongValueTypesProvider(): iterable
     {
         yield [['identifier' => 666]];
+        yield [['identifier_auth_hash' => 666]];
         yield [['language' => 666]];
         yield [['timezone' => 'wrongType']];
         yield [['game_version' => 666]];


### PR DESCRIPTION
Hello, submitting this PR to add the external_user_id_auth_hash parameter to the device resolver.

It will allow to enable Identity Verification for OneSignal : https://documentation.onesignal.com/docs/identity-verification

The parameter is listed here : https://documentation.onesignal.com/reference/edit-device#body-parameters

Thank you :)