### PR TITLE
Update NotificationResolver.php for support ios_interruption_level

### DIFF
--- a/src/Resolver/NotificationResolver.php
+++ b/src/Resolver/NotificationResolver.php
@@ -216,6 +216,8 @@ class NotificationResolver implements ResolverInterface
             ->setAllowedTypes('summary_arg', 'string')
             ->setDefined('summary_arg_count')
             ->setAllowedTypes('summary_arg_count', 'int')
+            ->setDefined('ios_interruption_level')
+            ->setAllowedTypes('ios_interruption_level', 'string')
             ->setDefined('ttl')
             ->setAllowedTypes('ttl', 'int')
             ->setDefined('priority')

--- a/tests/Fixtures/notifications_get_all.json
+++ b/tests/Fixtures/notifications_get_all.json
@@ -85,6 +85,7 @@
       "tags": null,
       "filters": null,
       "template_id": null,
+      "ios_interruption_level": "active",
       "ttl": null,
       "url": "https://mysite.com",
       "web_url": null,

--- a/tests/NotificationsTest.php
+++ b/tests/NotificationsTest.php
@@ -161,6 +161,7 @@ class NotificationsTest extends ApiTestCase
                     'tags' => null,
                     'filters' => null,
                     'template_id' => null,
+                    'ios_interruption_level' => 'active',
                     'ttl' => null,
                     'url' => 'https://mysite.com',
                     'web_url' => null,

--- a/tests/Resolver/NotificationResolverTest.php
+++ b/tests/Resolver/NotificationResolverTest.php
@@ -114,6 +114,7 @@ class NotificationResolverTest extends OneSignalTestCase
             'thread_id' => 'value',
             'summary_arg' => 'value',
             'summary_arg_count' => 10,
+            'ios_interruption_level' => 'value',
             'ttl' => 23,
             'priority' => 10,
             'app_id' => 'value',
@@ -212,6 +213,7 @@ class NotificationResolverTest extends OneSignalTestCase
         yield [['android_group_message' => 666]];
         yield [['adm_group' => 666]];
         yield [['adm_group_message' => 666]];
+        yield [['ios_interruption_level' => 666]];
         yield [['ttl' => 'wrongType']];
         yield [['priority' => 'wrongType']];
         yield [['app_id' => 666]];


### PR DESCRIPTION
Update NotificationResolver.php for support ios_interruption_level option
please check https://documentation.onesignal.com/reference/push-channel-properties#grouping--collapsing