### PR TITLE
Updated packages (for Symfony 8)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
         "psr/http-factory": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "symfony/deprecation-contracts": "^2.1|^3.0",
-        "symfony/options-resolver": "^4.4|^5.0|^6.0|^7.0"
+        "symfony/options-resolver": "^4.4|^5.0|^6.0|^7.0|^8"
     },
     "require-dev": {
         "nyholm/psr7": "^1.8.1",
         "php-cs-fixer/shim": "^v3.64.0",
         "phpstan/phpstan": "^1.12.0",
         "phpstan/phpstan-phpunit": "^1.4.0",
-        "symfony/http-client": "^5.0|^6.2|^7.0",
-        "symfony/phpunit-bridge": "^5.3|^6.2|^7.0"
+        "symfony/http-client": "^5.0|^6.2|^7.0|^8",
+        "symfony/phpunit-bridge": "^5.3|^6.2|^7.0|^8"
     },
     "autoload": {
         "psr-4": { "OneSignal\\": "src/" }


### PR DESCRIPTION
I've added Symfony 8 packages to be used as dependencies of this one - this allows anyone whom wants to upgrade to Symfony v8 (which was released in November 2025) to do-so.

I've done a basic test to send a one-signal notification which worked fine, and run php-cs-fixer over it too (which reported a few vars which could be changed to private from protected).