### PR TITLE
Fix phpstan variable visibility (with package update for Symfony 8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
                       symfony-version: 6.4.*
                     - php-version: 8.3
                       symfony-version: 7.0.*
+                    - php-version: 8.5
+                      symfony-version: 8.0.*
         steps:
             - name: "Checkout"
               uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
         "psr/http-factory": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "symfony/deprecation-contracts": "^2.1|^3.0",
-        "symfony/options-resolver": "^4.4|^5.0|^6.0|^7.0"
+        "symfony/options-resolver": "^4.4|^5.0|^6.0|^7.0|^8"
     },
     "require-dev": {
         "nyholm/psr7": "^1.8.1",
         "php-cs-fixer/shim": "^v3.64.0",
         "phpstan/phpstan": "^1.12.0",
         "phpstan/phpstan-phpunit": "^1.4.0",
-        "symfony/http-client": "^5.0|^6.2|^7.0",
-        "symfony/phpunit-bridge": "^5.3|^6.2|^7.0"
+        "symfony/http-client": "^5.0|^6.2|^7.0|^8",
+        "symfony/phpunit-bridge": "^5.3|^6.2|^7.0|^8"
     },
     "autoload": {
         "psr-4": { "OneSignal\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,8 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "conflict": {
+        "symfony/http-client": "<5.4.47|>=6,<6.4.15|>=7,<7.1.8"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php-cs-fixer/shim": "^v3.64.0",
         "phpstan/phpstan": "^1.12.0",
         "phpstan/phpstan-phpunit": "^1.4.0",
-        "symfony/http-client": "^5.0|^6.2|^7.0|^8",
+        "symfony/http-client": "^5.4.47|^6.4.15|^7.1.8|^8.0",
         "symfony/phpunit-bridge": "^5.3|^6.2|^7.0|^8"
     },
     "autoload": {

--- a/src/Response/Segment/CreateSegmentResponse.php
+++ b/src/Response/Segment/CreateSegmentResponse.php
@@ -8,12 +8,12 @@ use OneSignal\Response\AbstractResponse;
 
 final class CreateSegmentResponse implements AbstractResponse
 {
-    protected bool $success;
+    private bool $success;
 
     /**
      * @var non-empty-string
      */
-    protected string $id;
+    private string $id;
 
     /**
      * @param non-empty-string $id

--- a/src/Response/Segment/DeleteSegmentResponse.php
+++ b/src/Response/Segment/DeleteSegmentResponse.php
@@ -8,7 +8,7 @@ use OneSignal\Response\AbstractResponse;
 
 final class DeleteSegmentResponse implements AbstractResponse
 {
-    protected bool $success;
+    private bool $success;
 
     public function __construct(bool $success)
     {

--- a/src/Response/Segment/ListSegmentsResponse.php
+++ b/src/Response/Segment/ListSegmentsResponse.php
@@ -12,22 +12,22 @@ final class ListSegmentsResponse implements AbstractResponse
     /**
      * @var non-negative-int
      */
-    protected int $totalCount;
+    private int $totalCount;
 
     /**
      * @var int<0, 2147483648>
      */
-    protected int $offset;
+    private int $offset;
 
     /**
      * @var int<0, 2147483648>
      */
-    protected int $limit;
+    private int $limit;
 
     /**
      * @var list<Segment>
      */
-    protected array $segments;
+    private array $segments;
 
     /**
      * @param non-negative-int   $totalCount


### PR DESCRIPTION
This PR is in addition to https://github.com/norkunas/onesignal-php-api/pull/189 to address PHPStan's issue with the variable visibility in a few of the classes which are marked as 'final' - it shouldn't have any effect.
I've done a basic test (sending a notification) which worked without issue.